### PR TITLE
Add taxa class and find by sis id method

### DIFF
--- a/src/iucnredlistpy/__init__.py
+++ b/src/iucnredlistpy/__init__.py
@@ -1,5 +1,6 @@
 from .client import Client
 from .resource import Resource
 from .assessment import Assessment
+from .taxa import Taxa
 
-__all__ = ["Resource", "Client", "Assessment"]
+__all__ = ["Resource", "Client", "Assessment", "Taxa"]

--- a/src/iucnredlistpy/client.py
+++ b/src/iucnredlistpy/client.py
@@ -2,6 +2,7 @@ import requests
 from .constants import RESOURCE_NAMES
 from .resource import Resource
 from .assessment import Assessment
+from .taxa import Taxa
 
 
 class Client:
@@ -10,6 +11,7 @@ class Client:
         self.session = self._initialize_session()
         self._define_resource_methods()
         self.assessment = Assessment(self)
+        self.taxa = Taxa(self)
 
     def get(self, url, params=None):
         response = self.session.get(url, params=params)

--- a/src/iucnredlistpy/taxa.py
+++ b/src/iucnredlistpy/taxa.py
@@ -1,0 +1,11 @@
+from .constants import API_BASE
+
+
+class Taxa:
+    def __init__(self, client):
+        self.client = client
+
+    def sis(self, sis_id):
+        url = f"{API_BASE}taxa/sis/{sis_id}"
+        print(url)
+        return self.client.get(url)

--- a/tests/test_taxa.py
+++ b/tests/test_taxa.py
@@ -1,0 +1,18 @@
+import iucnredlistpy
+
+
+def test_sis_find(requests_mock):
+    api_key = "fake-api-key"
+    client = iucnredlistpy.Client(api_key=api_key)
+
+    mock_url = "https://api.iucnredlist.org/api/v4/taxa/sis/123"
+    mock_response = {
+        "assessment_id": 123,
+        "assessment_date": "2023-01-27T00:00:00.000Z",
+        "year_published": "2024",
+    }
+
+    requests_mock.get(mock_url, json=mock_response)
+
+    result = client.taxa.sis(123)
+    assert result == mock_response


### PR DESCRIPTION
This PR adds a taxa class.

It can be used by opening a Python REPL with e.g. `uv`:

```
uv run python
```
Then Initialise the client
```
import iucnredlistpy

client = iucnredlistpy.Client(api_key="your_red_list_api_key")
```
Then running e.g.
```
>>> client.taxa.sis(163424)
https://api.iucnredlist.org/api/v4/taxa/sis/163424
{'sis_id': 163424, 'taxon': {'sis_id': 163424, 'scientific_name': 'Chelydra serpentina', 'species_taxa': [], 'subpopulation_taxa': [], 'infrarank_taxa': [], 'kingdom_name': 'ANIMALIA', 'phylum_name': 'CHORDATA', 'class_name': 'REPTILIA', 'order_name': 'TESTUDINES', 'family_name': 'CHELYDRIDAE', 'genus_name': 'Chelydra', 'species_name': 'serpentina', 'subpopulation_name': None, 'infra_name': None, 'authority': '(Linnaeus, 1758)', 'species': True, 'subpopulation': False, 'infrarank': False, 'ssc_groups': [{'name': 'IUCN SSC Tortoise and Freshwater Turtle Specialist Group', 'url': 'http://www.iucn-tftsg.org/', 'description': 'Chair: Craig Stanford (email: stanford@usc.edu)\nRed List Authority Coordinator: Carla Eisemberg (email:Carla.Eisemberg@cdu.edu.au)\nNewsletters: Chelonian Conservation and Biology (http://www.chelonian.org/ccb/); Turtle and Tortoise Newsletter (http://www.chelonian.org/crf-publications/turtle-and-tortoise-newsletter/); TurtleLog Online Newsletter (http://www.iucn-tftsg.org/turtlelog_online_newsletter/)'}], 'common_names': [{'main': False, 'name': 'Common Snapping Turtle', 'language': 'eng'}, {'main': False, 'name': 'North American Snapping Turtle', 'language': 'eng'}, {'main': False, 'name': 'Tortue serpentine', 'language': 'fre'}, {'main': True, 'name': 'Snapping Turtle', 'language': 'eng'}], 'synonyms': [{'name': 'Chelydra osceola Stejneger, 1918', 'status': 'ACCEPTED', 'genus_name': 'Chelydra', 'species_name': 'osceola', 'species_author': 'Stejneger, 1918', 'infrarank_author': None, 'subpopulation_name': None, 'infra_type': None, 'infra_name': None}, {'name': 'Testudo serpentina Linnaeus, 1758', 'status': 'ACCEPTED', 'genus_name': 'Testudo', 'species_name': 'serpentina', 'species_author': 'Linnaeus, 1758', 'infrarank_author': None, 'subpopulation_name': None, 'infra_type': None, 'infra_name': None}, {'name': 'Chelydra emarginata Agassiz, 1857', 'status': 'ACCEPTED', 'genus_name': 'Chelydra', 'species_name': 'emarginata', 'species_author': 'Agassiz, 1857', 'infrarank_author': None, 'subpopulation_name': None, 'infra_type': None, 'infra_name': None}]}, 'assessments': [{'year_published': '2024', 'latest': True, 'possibly_extinct': False, 'possibly_extinct_in_the_wild': False, 'sis_taxon_id': 163424, 'url': 'https://www.iucnredlist.org/species/163424/222880455', 'taxon_scientific_name': 'Chelydra serpentina', 'red_list_category_code': 'NA', 'assessment_id': 222880455, 'scopes': [{'description': {'en': 'Europe'}, 'code': '2'}]}, {'year_published': '2025', 'latest': True, 'possibly_extinct': False, 'possibly_extinct_in_the_wild': False, 'sis_taxon_id': 163424, 'url': 'https://www.iucnredlist.org/species/163424/251347989', 'taxon_scientific_name': 'Chelydra serpentina', 'red_list_category_code': 'LC', 'assessment_id': 251347989, 'scopes': [{'description': {'en': 'Global'}, 'code': '1'}]}, {'year_published': '2012', 'latest': False, 'possibly_extinct': False, 'possibly_extinct_in_the_wild': False, 'sis_taxon_id': 163424, 'url': 'https://www.iucnredlist.org/species/163424/18547887', 'taxon_scientific_name': 'Chelydra serpentina', 'red_list_category_code': 'LC', 'assessment_id': 18547887, 'scopes': [{'description': {'en': 'Global'}, 'code': '1'}]}, {'year_published': '2012', 'latest': False, 'possibly_extinct': False, 'possibly_extinct_in_the_wild': False, 'sis_taxon_id': 163424, 'url': 'https://www.iucnredlist.org/species/163424/97408395', 'taxon_scientific_name': 'Chelydra serpentina', 'red_list_category_code': 'LC', 'assessment_id': 97408395, 'scopes': [{'description': {'en': 'Global'}, 'code': '1'}]}, {'year_published': '2011', 'latest': False, 'possibly_extinct': False, 'possibly_extinct_in_the_wild': False, 'sis_taxon_id': 163424, 'url': 'https://www.iucnredlist.org/species/163424/5605197', 'taxon_scientific_name': 'Chelydra serpentina', 'red_list_category_code': 'LC', 'assessment_id': 5605197, 'scopes': [{'description': {'en': 'Global'}, 'code': '1'}]}, {'year_published': '2010', 'latest': False, 'possibly_extinct': False, 'possibly_extinct_in_the_wild': False, 'sis_taxon_id': 163424, 'url': 'https://www.iucnredlist.org/species/163424/5605161', 'taxon_scientific_name': 'Chelydra serpentina', 'red_list_category_code': 'LR/lc', 'assessment_id': 5605161, 'scopes': [{'description': {'en': 'Global'}, 'code': '1'}]}]}
```

Methods for other taxa endpoints will be added in follow up PR's.